### PR TITLE
fix: Use generates/merger instead of merge lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var through = require("through2");
 var ngAnnotate = require("ng-annotate-patched");
 var applySourceMap = require("vinyl-sourcemaps-apply");
-var merge = require("merge");
+var { merge } = require("@generates/merger");
 var BufferStreams = require("bufferstreams");
 var PluginError = require("plugin-error");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "gulp-ng-annotate",
-  "version": "2.1.0",
+  "name": "fyle-gulp-ng-annotate-patched",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gulp-ng-annotate",
-      "version": "2.1.0",
+      "name": "fyle-gulp-ng-annotate-patched",
+      "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
+        "@generates/merger": "^0.1.3",
         "bufferstreams": "^1.1.3",
-        "merge": "^1.2.1",
         "ng-annotate-patched": "^1.14.1",
         "plugin-error": "^0.1.2",
         "through2": "^2.0.5",
@@ -24,6 +24,12 @@
       "engines": {
         "node": ">=18.20.4"
       }
+    },
+    "node_modules/@generates/merger": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@generates/merger/-/merger-0.1.3.tgz",
+      "integrity": "sha512-x4KKHexiP4hIfoGZumc3RSac1t9d/aGErxbG9NASHcx59mljW2uyKDt4qP3igi9hszIHV5mjb4TbAYUNFoWg3w==",
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/@gulp-sourcemaps/identity-map": {
       "version": "2.0.1",
@@ -970,11 +976,6 @@
       "engines": {
         "node": ">=0.12"
       }
-    },
-    "node_modules/merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "node_modules/minimatch": {
       "version": "5.1.6",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/fylein/gulp-ng-annotate-patched",
   "dependencies": {
+    "@generates/merger": "^0.1.3",
     "bufferstreams": "^1.1.3",
-    "merge": "^1.2.1",
     "ng-annotate-patched": "^1.14.1",
     "plugin-error": "^0.1.2",
     "through2": "^2.0.5",


### PR DESCRIPTION
`All versions of package @ianwalter/merge are vulnerable to Prototype Pollution via the main (merge) function. Maintainer suggests using @generates/merger instead.`